### PR TITLE
46 problem with unbalanced panel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: eventstudyr
 Title: Estimation and Visualization of Linear Panel Event Studies
-Version: 1.1.2
+Version: 1.1.3
 Authors@R: 
     c(person(given = "Simon",
            family = "Freyaldenhoven",

--- a/R/ComputeShifts.R
+++ b/R/ComputeShifts.R
@@ -90,7 +90,7 @@ ComputeShifts <- function(df, idvar, timevar, shiftvar, shiftvalues,
 
         ## Bring shifts back to the original dataset
         df <- merge(df, df_all,
-                    by = c(idvar, timevar), all.x = TRUE)
+                    by = c(idvar, timevar, shiftvar), all.x = TRUE)
     }
 
     if (return_df) {

--- a/R/EventStudy.R
+++ b/R/EventStudy.R
@@ -103,6 +103,23 @@
 #'
 #' summary(eventstudy_model_static$output)
 #'
+#' # A dynamic model with an unbalanced panel#'
+#' data_unbal <- example_data[1:(nrow(example_data)-1),]  # drop last row to make unbalanced
+#'
+#' eventstudy_model_unbal <-
+#'  EventStudy(
+#'     estimator = "OLS",
+#'     data = data_unbal,
+#'     outcomevar = "y_base",
+#'     policyvar = "z",
+#'     idvar = "id",
+#'     timevar = "t",
+#'     pre = 0, post = 3,
+#'     normalize = -1
+#'   )
+#'
+#' summary(eventstudy_model_unbal$output)
+#'
 #' # A dynamic model estimated using IV
 #' eventstudy_model_iv <-
 #'   EventStudy(
@@ -184,15 +201,15 @@ EventStudy <- function(estimator, data, outcomevar, policyvar, idvar, timevar, c
     detect_holes <- function(dt, idvar, timevar) {
         dt <- data.table::as.data.table(dt)
         holes_per_id <- dt[, .SD[!is.na(base::get(timevar))], by = c(idvar)
-                         ][, list(holes = any(base::diff(base::get(timevar)) != 1)), 
+                         ][, list(holes = any(base::diff(base::get(timevar)) != 1)),
                             by = c(idvar)]
-        
+
         return(any(holes_per_id$holes))
     }
 
     if (detect_holes(data, idvar, timevar)) {
-        warning(paste0("Note: gaps of more than one in the time variable '", timevar, "' were detected. ",
-                       "Treating these as gaps in the panel."))
+        warning(paste0("Note: gaps of more than one unit in the time variable '", timevar, "' were detected. ",
+                       "Treating these as gaps in the panel dimension."))
         timevar_holes <- TRUE
     } else {
         timevar_holes <- FALSE
@@ -228,11 +245,9 @@ EventStudy <- function(estimator, data, outcomevar, policyvar, idvar, timevar, c
 
         if ((post + overidpost - 1 >= 1) & (pre + overidpre >= 1)) {
             shift_values = c(-num_fd_leads:-1, 1:num_fd_lags)
-        }
-        else if (pre + overidpre < 1) {
+        } else if (pre + overidpre < 1) {
             shift_values = 1:num_fd_lags
-        }
-        else if (post + overidpost - 1 < 1) {
+        } else if (post + overidpost - 1 < 1) {
             shift_values = -num_fd_leads:-1
         }
 

--- a/man/EventStudy.Rd
+++ b/man/EventStudy.Rd
@@ -143,6 +143,23 @@ eventstudy_model_static <-
 
 summary(eventstudy_model_static$output)
 
+# A dynamic model with an unbalanced panel#'
+data_unbal <- example_data[1:(nrow(example_data)-1),]  # drop last row to make unbalanced
+
+eventstudy_model_unbal <-
+ EventStudy(
+    estimator = "OLS",
+    data = data_unbal,
+    outcomevar = "y_base",
+    policyvar = "z",
+    idvar = "id",
+    timevar = "t",
+    pre = 0, post = 3,
+    normalize = -1
+  )
+
+summary(eventstudy_model_unbal$output)
+
 # A dynamic model estimated using IV
 eventstudy_model_iv <-
   EventStudy(

--- a/tests/testthat/test-ComputeShifts.R
+++ b/tests/testthat/test-ComputeShifts.R
@@ -67,6 +67,27 @@ test_that("the columns added have correct suffixes", {
     expect_true(all(grepl("_lead", v_newvars)))
 })
 
+test_that("correctly shifts variable when there are no holes in timevar", {
+    df <- data.frame(
+        id      = c(rep("A", 4), rep("B", 2), rep("C", 3)),
+        time    = c(1, 2, 3, 4, 1, 2, 1, 2, 3),
+        z       = c(10, 12, 13, 14, 8, 9, 10, 11, 12),
+        z_lag1  = c(NA, 10, 12, 13, NA, 8, NA, 10, 11),
+        z_lead1 = c(12, 13, 14, NA, 9, NA, 11, 12, NA)
+    )
+
+    df_shifts <- ComputeShifts(df[, c("id", "time", "z")],
+                               idvar = "id", timevar = "time",
+                               shiftvar = "z",
+                               shiftvalues = c(-1, 1),
+                               timevar_holes = FALSE)
+
+    expect_equal(df$z_lead1, df_shifts$z_lead1)
+    expect_equal(df$z_lag1,  df_shifts$z_lag1)
+
+    expect_true(all(c("id", "time", "z") %in% colnames(df_shifts)))
+})
+
 test_that("correctly shifts variable when there are holes in timevar", {
     df <- data.frame(
         id      = c(rep("A", 4), rep("B", 2), rep("C", 3)),
@@ -84,4 +105,6 @@ test_that("correctly shifts variable when there are holes in timevar", {
 
     expect_equal(df$z_lead1, df_shifts$z_lead1)
     expect_equal(df$z_lag1,  df_shifts$z_lag1)
+
+    expect_true(all(c("id", "time", "z") %in% colnames(df_shifts)))
 })

--- a/vignettes/documentation.Rmd
+++ b/vignettes/documentation.Rmd
@@ -69,7 +69,7 @@ results <- EventStudy(estimator = "OLS",
                       pre = 0)
 ```
 ```{r Basic Eventstudy Example - Show Results 1, echo=TRUE, eval=TRUE}
-    summary(results$output)
+summary(results$output)
 ```
 <details>
   <summary>Click for `results$arguments`</summary>
@@ -92,7 +92,7 @@ results <- EventStudy(estimator = "OLS",
   results$arguments$proxy
   results$arguments$proxyIV
   
-  ## Fixed Effects
+  ## Fixed effects
   results$arguments$FE
   results$arguments$TFE
   
@@ -109,7 +109,7 @@ results <- EventStudy(estimator = "OLS",
   ## Cluster
   results$arguments$cluster
   
-  ## Eventstudy Coefficient
+  ## Eventstudy coefficients
   results$arguments$eventstudy_coefficients
   ```
 </details>


### PR DESCRIPTION
Hi @ew487! Could you quickly double-check that this solves the issue in #46?

The issue was related to merging two datasets within `ComputeShifts` for the case of unbalanced panels. As precisely explained by @yang-yuchuan in #46, this problematic merge change the name of the first differenced value causing the function to break. What I did is:
- Fix the issue as suggested in #46
- Added tests in ` ComputeShifts` to make sure this doesn't happen again
- Added a full example with unbalanced panels that is ran every time we build the package

One more thing to do before merging is to increase the version number. I think we should do this as this is an important fix.